### PR TITLE
Correction of module location

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/helloeave/json
+module github.com/homelight/json
 
 go 1.13


### PR DESCRIPTION
Fix for error:
```
module declares its path as: github.com/helloeave/json
        but was required as: github.com/homelight/json
```