### PR TITLE
fix: marshal empty byte slices into empty strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 This is a fork of [golang's encoding/json](https://github.com/golang/go/tree/master/src/encoding/json) with an extra method `MarshalSafeCollections` that marshals nil slices and maps into `[]` and `{}` respectfully instead of `null`. Additionally added `SetNilSafeCollection` to the `Encoder` in order to turn on the flag (default: false).
 
 The semantic versioning for this repository follows that of the go src version that it forks from.
+
+# Changelog
+
+## v1.18
+
+- BREAKING CHANGE: Empty byte slices are now marshaled into empty strings, rather than arrays (#4)

--- a/encode.go
+++ b/encode.go
@@ -857,7 +857,7 @@ func newMapEncoder(t reflect.Type) encoderFunc {
 func encodeByteSlice(e *encodeState, v reflect.Value, opts encOpts) {
 	if v.IsNil() {
 		if opts.nilSafeCollection {
-			e.WriteString("[]")
+			e.WriteString(`""`)
 		} else {
 			e.WriteString("null")
 		}

--- a/encode_test.go
+++ b/encode_test.go
@@ -7,6 +7,7 @@ package json
 import (
 	"bytes"
 	"encoding"
+	"encoding/base64"
 	"fmt"
 	"log"
 	"math"
@@ -1208,6 +1209,8 @@ func TestMarshalSafeCollections(t *testing.T) {
 		pNilSlice *[]interface{}
 		nilMap    map[string]interface{}
 		pNilMap   *map[string]interface{}
+		nilBytes  []byte
+		pNilBytes *[]byte
 	)
 	type (
 		nilSliceStruct struct {
@@ -1215,6 +1218,9 @@ func TestMarshalSafeCollections(t *testing.T) {
 		}
 		nilMapStruct struct {
 			NilMap map[string]interface{} `json:"nil_map"`
+		}
+		nilBytesStruct struct {
+			NilBytes []byte `json:"nil_bytes"`
 		}
 	)
 	tests := []struct {
@@ -1226,13 +1232,18 @@ func TestMarshalSafeCollections(t *testing.T) {
 		{make([]interface{}, 0), "[]"},
 		{[]int{1, 2, 3}, "[1,2,3]"},
 		{pNilSlice, "null"},
-		{nilSliceStruct{}, "{\"nil_slice\":[]}"},
+		{nilSliceStruct{}, `{"nil_slice":[]}`},
 		{nilMap, "{}"},
 		{map[string]interface{}{}, "{}"},
 		{make(map[string]interface{}, 0), "{}"},
-		{map[string]interface{}{"1": 1, "2": 2, "3": 3}, "{\"1\":1,\"2\":2,\"3\":3}"},
+		{map[string]interface{}{"1": 1, "2": 2, "3": 3}, `{"1":1,"2":2,"3":3}`},
 		{pNilMap, "null"},
-		{nilMapStruct{}, "{\"nil_map\":{}}"},
+		{nilMapStruct{}, `{"nil_map":{}}`},
+		{nilBytes, `""`},
+		{[]byte{}, `""`},
+		{[]byte("hello"), `"` + base64.StdEncoding.EncodeToString([]byte("hello")) + `"`},
+		{pNilBytes, `null`},
+		{nilBytesStruct{}, `{"nil_bytes":""}`},
 	}
 	for i, tt := range tests {
 		b, err := MarshalSafeCollections(tt.in)


### PR DESCRIPTION
The library marshals byte slices into base64-encoded strings. For consistency, empty byte slices should be marshaled into empty strings.

I also reformatted the test strings so that we don't have to escape `"` characters anymore.